### PR TITLE
fix: fix es search query content-type & log level

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -46,16 +46,16 @@ func init() {
 		parser.ParseArgs(args)
 	}
 
-	log.Infof("esalert opts: %+v", Opts)
-}
-
-func init() {
-	if level, err := log.ParseLevel(strings.ToLower(Opts.LogLevel)); err != nil {
-		log.SetLevel(level)
-	}
-
 	log.SetFormatter(&log.TextFormatter{
 		FullTimestamp:   true,
 		TimestampFormat: time.RFC3339,
 	})
+	level, err := log.ParseLevel(strings.ToLower(Opts.LogLevel))
+	if err == nil {
+		log.SetLevel(level)
+	} else {
+		log.Errorf("invalid log level: %s", Opts.LogLevel)
+	}
+
+	log.Infof("esalert opts: %+v", Opts)
 }

--- a/search/search.go
+++ b/search/search.go
@@ -106,7 +106,11 @@ func Search(index, typ string, search interface{}) (Result, error) {
 		return Result{}, err
 	}
 
-	req, err := http.NewRequest("GET", u, bytes.NewBuffer(bodyReq))
+	log.WithFields(log.Fields{
+		"body": string(bodyReq),
+	}).Debugln("search query")
+
+	req, err := http.NewRequest(http.MethodPost, u, bytes.NewBuffer(bodyReq))
 	if err != nil {
 		return Result{}, err
 	}
@@ -114,6 +118,8 @@ func Search(index, typ string, search interface{}) (Result, error) {
 	if config.Opts.ElasticSearchUser != "" && config.Opts.ElasticSearchPass != "" {
 		req.SetBasicAuth(config.Opts.ElasticSearchUser, config.Opts.ElasticSearchPass)
 	}
+
+	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
Hi,

This PR set elasticsearch query using http POST method and help to fix log level config

As we can see, we set log level when error occurs only:
https://github.com/Akagi201/esalert/blob/413542e8c1f40d246779272d62faaec073a4aca3/config/config.go#L53-L55